### PR TITLE
default log to stdout and make a bit more configurable

### DIFF
--- a/files/start.sh
+++ b/files/start.sh
@@ -17,7 +17,8 @@ com.cloudera.cmf.db.password=${DB_PASSWORD}
 EOF
 
 ## Default env
-source /etc/default/cloudera-scm-server
+export CMF_JDBC_DRIVER_JAR=${CMF_JDBC_DRIVER_JAR:-/usr/share/java/mysql-connector-java.jar:/usr/share/java/oracle-connector-java.jar}
+export CMF_JAVA_OPTS=${CMF_JAVA_OPTS:--Xmx2G -XX:MaxPermSize=256m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp -Dcmf.root.logger=INFO,LOGFILE,CONSOLE}
 
 ## Log config and env for troubleshooting
 cat 1>&2 << EOF
@@ -30,4 +31,4 @@ $(env)
 /usr/sbin/cmf-server:
 EOF
 
-exec /usr/sbin/cmf-server
+exec /usr/sbin/cmf-server $*


### PR DESCRIPTION
CM _really_ wants to log to a file. It fails to start if you log only to console. I suspect this is so that you can tail logs through the web ui or something. This change effectively sets the log4j.rootLogger to append both to the default log file as well as the console. This lets us collect/view cm's logs through docker logs.
